### PR TITLE
Fix LLMResponseParser import - restore lazy loading pattern

### DIFF
--- a/cf/agents/multi_pass_coordinator.py
+++ b/cf/agents/multi_pass_coordinator.py
@@ -8,8 +8,6 @@ Extracted from SupervisorAgent for better maintainability and testability.
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
 
-from cf.utils.llm_parser import LLMResponseParser
-
 
 @dataclass
 class PassState:
@@ -166,6 +164,8 @@ Provide JSON response:
 
         # Get LLM decision
         try:
+            from cf.utils.llm_parser import LLMResponseParser
+
             llm_response = self.llm_callback(prompt, "You are analyzing multi-pass coordination. Return JSON only.")
 
             result = LLMResponseParser.safe_parse_llm_response(


### PR DESCRIPTION
CRITICAL FIX - Restore lazy loading for LLMResponseParser:
- Move import back inside try block (line 167)
- Was causing runtime error: 'name LLMResponseParser is not defined'
- Lazy loading prevents import-time circular dependency issues
- This is the correct pattern for this case

Why this is correct:
- Multi-pass coordinator is imported early in supervisor chain
- Top-level import can cause circular dependency problems
- Lazy loading inside try block avoids import-time issues
- This is an acceptable PEP 8 exception per Python best practices

Final mid-file imports (both acceptable):
1. multi_pass_coordinator.py:167 - LLMResponseParser (lazy load in try)
2. structural.py:672 - LLMClient (lazy load in try)

Both follow Python best practice for avoiding circular imports.

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No testing needed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.