### PR TITLE
Resolve entry point names to KB functions for life-of-x tracing

### DIFF
--- a/cf/agents/pipelines/structural.py
+++ b/cf/agents/pipelines/structural.py
@@ -516,31 +516,40 @@ class StructuralPipeline:
             try:
                 entry_point = intent.get('entry_point', '')
                 if entry_point and self.lifeofx_config.get('enabled', False):
-                    paths = self.trace_execution_path(entry_point, max_depth=10, max_paths=5)
-                    print(f"✅ [KB_LIFEOFX] Found {len(paths)} execution paths")
+                    # Resolve entry point to actual function names in KB
+                    resolved_entry_points = self._resolve_entry_point(entry_point)
 
-                    files_extracted = 0
-                    for path_info in paths:
-                        steps = path_info.get('steps', [])
-                        print(f"   [DEBUG] Path has {len(steps)} steps")
+                    if not resolved_entry_points:
+                        print(f"⚠️ [KB_LIFEOFX] Could not resolve entry point: {entry_point}")
+                    else:
+                        print(f"✅ [KB_LIFEOFX] Resolved entry point '{entry_point}' to {len(resolved_entry_points)} function(s)")
 
-                        for step in steps:
-                            # Extract file_path from qualified_name (format: "path/to/file.py::function")
-                            qualified_name = step.get('qualified_name', '')
-                            print(f"   [DEBUG] Step qualified_name: {qualified_name}")
+                        all_paths = []
+                        for resolved_ep in resolved_entry_points[:3]:  # Limit to 3 entry points
+                            paths = self.trace_execution_path(resolved_ep, max_depth=10, max_paths=5)
+                            all_paths.extend(paths)
 
-                            if '::' in qualified_name:
-                                file_path = qualified_name.split('::')[0]
-                                if file_path:
-                                    # High relevance for execution flow files
-                                    file_scores[file_path] = max(file_scores.get(file_path, 0), 0.9)
-                                    file_paths.append(file_path)
-                                    files_extracted += 1
-                                    print(f"   [DEBUG] Extracted file: {file_path}")
-                            else:
-                                print(f"   [DEBUG] No '::' separator in qualified_name")
+                        print(f"✅ [KB_LIFEOFX] Found {len(all_paths)} execution paths")
 
-                    print(f"   [DEBUG] Total files extracted from life-of-x: {files_extracted}")
+                        files_extracted = 0
+                        for path_info in all_paths:
+                            steps = path_info.get('steps', [])
+
+                            for step in steps:
+                                # Extract file_path from qualified_name (format: "path/to/file.py::function")
+                                qualified_name = step.get('qualified_name', '')
+
+                                if '::' in qualified_name:
+                                    file_path = qualified_name.split('::')[0]
+                                    if file_path:
+                                        # High relevance for execution flow files
+                                        file_scores[file_path] = max(file_scores.get(file_path, 0), 0.9)
+                                        file_paths.append(file_path)
+                                        files_extracted += 1
+
+                        if files_extracted > 0:
+                            print(f"✅ [KB_LIFEOFX] Extracted {files_extracted} files from execution paths")
+
             except Exception as e:
                 print(f"⚠️ [KB_LIFEOFX] Execution tracing failed: {e}")
                 import traceback
@@ -669,6 +678,60 @@ class StructuralPipeline:
         ranked_files = sorted(unique_files, key=lambda f: file_scores.get(f, 0.5), reverse=True)
 
         return ranked_files[:max_results]
+
+    def _resolve_entry_point(self, entry_point: str) -> List[str]:
+        """
+        Resolve a high-level entry point name to actual qualified function names in KB.
+
+        Args:
+            entry_point: User-provided entry point (e.g., "student application", "user login")
+
+        Returns:
+            List of qualified function names found in KB
+        """
+        if not self.is_kb_available():
+            return []
+
+        resolved = []
+
+        # Split entry point into keywords for searching
+        keywords = entry_point.lower().split()
+
+        try:
+            # Search for matching functions
+            for keyword in keywords:
+                result = self.kb.search_by_name(keyword, self.repo_id, node_type='Function')
+                for node in result.nodes:
+                    qualified_name = node.get('qualified_name')
+                    if qualified_name and qualified_name not in resolved:
+                        resolved.append(qualified_name)
+
+            # Also search for matching classes (entry points might be classes)
+            for keyword in keywords:
+                result = self.kb.search_by_name(keyword, self.repo_id, node_type='Class')
+                for node in result.nodes:
+                    qualified_name = node.get('qualified_name')
+                    if qualified_name and qualified_name not in resolved:
+                        resolved.append(qualified_name)
+
+            # Sort by relevance - prefer exact matches
+            def relevance_score(qname):
+                name_lower = qname.lower()
+                score = 0
+                # Exact match in any part
+                if any(kw in name_lower for kw in keywords):
+                    score += 10
+                # All keywords present
+                if all(kw in name_lower for kw in keywords):
+                    score += 20
+                return score
+
+            resolved.sort(key=relevance_score, reverse=True)
+
+        except Exception as e:
+            print(f"⚠️ [KB_LIFEOFX] Entry point resolution failed: {e}")
+
+        return resolved[:10]  # Return top 10 matches
 
     def _analyze_question(self, question: str, llm_context: Dict[str, Any] = None) -> Dict[str, Any]:
         """


### PR DESCRIPTION
ROOT CAUSE:
- LLM extracts "student application" as entry_point from question
- trace_execution_path() expects qualified names like "src/apps.py::StudentApplication"
- Entry point not found in KB call graph → returns dummy 1-step path
- qualified_name = "student application" (no "::" separator)
- File extraction fails → 0 files found

SOLUTION:
Added _resolve_entry_point() method (lines 682-734):
- Searches KB for functions/classes matching keywords
- "student application" → searches for "student" AND "application"
- Returns qualified names: ["src/apps/models.py::StudentApplication", ...]
- Scores by relevance (exact match, all keywords present)
- Returns top 10 matches

Updated life-of-x section (lines 519-551):
- Resolves entry point BEFORE tracing
- Traces from actual KB function names (with ::)
- Collects files from all resolved entry points
- Cleaner logging (removed verbose debug)

EXPECTED BEHAVIOR:
Before: [KB_LIFEOFX] Found 1 execution paths → 0 files After:  [KB_LIFEOFX] Resolved 'student application' to 3 function(s)
        [KB_LIFEOFX] Found 5 execution paths
        [KB_LIFEOFX] Extracted 15 files from execution paths
        [GRAPH_QUERY] Found 15 files via graph queries ✅

This is the final fix for life-of-x KB graph queries.

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No testing needed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.