### PR TITLE
Improve: Reject all-utility results to trigger fallback strategies

### DIFF
--- a/cf/agents/pipelines/structural.py
+++ b/cf/agents/pipelines/structural.py
@@ -537,6 +537,9 @@ class StructuralPipeline:
 
                     if not resolved_entry_points:
                         print(f"⚠️ [KB_LIFEOFX] Could not resolve entry point: {entry_point}")
+                        print(f"   💡 [KB_LIFEOFX] Tip: Entry points like views.py or api.py may not exist,")
+                        print(f"   💡 [KB_LIFEOFX]      or they may not contain functions matching '{entry_point}'")
+                        print(f"   💡 [KB_LIFEOFX]      Other discovery strategies will try to find relevant files")
                     else:
                         print(f"✅ [KB_LIFEOFX] Resolved entry point '{entry_point}' to {len(resolved_entry_points)} function(s)")
 
@@ -889,10 +892,16 @@ class StructuralPipeline:
             # Extract just the qualified names
             resolved = [qname for qname, _ in unique_candidates]
 
-            # If no high-scoring results found, warn user
+            # If no high-scoring results found, warn user and potentially reject
             if resolved:
                 top_score = relevance_score(unique_candidates[0])
-                if top_score < 20:
+
+                # If ALL results are utilities (negative scores), reject and return empty
+                # This allows other discovery strategies to try finding better matches
+                if top_score < 0:
+                    print(f"   ⚠️ [KB_LIFEOFX] All matches are utilities (score: {top_score}). Rejecting to allow other strategies.")
+                    resolved = []  # Clear results to trigger other strategies
+                elif top_score < 20:
                     print(f"   ⚠️ [KB_LIFEOFX] Low confidence matches (score: {top_score}). May not be true entry points.")
 
             # If nothing found, try fallback with tests


### PR DESCRIPTION
Two key improvements to discovery pipeline:

1. Reject All-Utility Results (structural.py:898-900):
   - When ALL KB candidates score negative (all utilities), reject them
   - Returns empty list to trigger other discovery strategies
   - Prevents returning only utilities when better files may exist
   - Impact: Grep, domain detection, keyword strategies get a chance

2. Better User Messaging (structural.py:540-542):
   - Provide helpful tips when entry point resolution fails
   - Explain why resolution might fail (files don't exist or no matching functions)
   - Inform user that other strategies will try to find files

Example scenario:
- Before: KB finds only utilities (-25, -40, -40) → returns them
- After: KB finds only utilities → rejects → Grep searches code for usage

This improves discovery quality by ensuring we try multiple approaches when the KB doesn't have good entry point matches.

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No testing needed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.