### PR TITLE
Improve: Prioritize non-test files in Life-of-X fallback strategy

### DIFF
--- a/cf/agents/pipelines/structural.py
+++ b/cf/agents/pipelines/structural.py
@@ -904,15 +904,34 @@ class StructuralPipeline:
                 elif top_score < 20:
                     print(f"   ⚠️ [KB_LIFEOFX] Low confidence matches (score: {top_score}). May not be true entry points.")
 
-            # If nothing found, try fallback with tests
+            # If nothing found, try fallback - prioritize non-test files
             if not resolved:
-                print("   ⚠️ [KB_LIFEOFX] No non-test matches found, including test files")
+                print("   ⚠️ [KB_LIFEOFX] No entry point matches found, searching broader...")
+
+                # First pass: collect all candidates with their file paths
+                candidates = []
+                seen_qnames = set()
                 for keyword in keywords:
                     result = self.kb.search_by_name(keyword, self.repo_id, node_type='Function')
                     for node in result.nodes:
                         qualified_name = node.get('qualified_name')
-                        if qualified_name and qualified_name not in resolved:
-                            resolved.append(qualified_name)
+                        if qualified_name and qualified_name not in seen_qnames:
+                            seen_qnames.add(qualified_name)
+                            file_path = self.kb.get_file_path_for_qualified_name(qualified_name, self.repo_id)
+                            candidates.append((qualified_name, file_path))
+
+                # Prioritize non-test files over test files
+                non_test_candidates = [(qname, fpath) for qname, fpath in candidates if not self._is_test_file(fpath)]
+                test_candidates = [(qname, fpath) for qname, fpath in candidates if self._is_test_file(fpath)]
+
+                if non_test_candidates:
+                    print(f"   ✅ [KB_LIFEOFX] Found {len(non_test_candidates)} non-test function(s), prioritizing these over {len(test_candidates)} test files")
+                    resolved = [qname for qname, _ in non_test_candidates]
+                elif test_candidates:
+                    print(f"   ⚠️ [KB_LIFEOFX] No non-test matches found, falling back to {len(test_candidates)} test file(s)")
+                    resolved = [qname for qname, _ in test_candidates]
+                else:
+                    print("   ❌ [KB_LIFEOFX] No matches found at all")
 
         except Exception as e:
             print(f"⚠️ [KB_LIFEOFX] Entry point resolution failed: {e}")


### PR DESCRIPTION
When the primary entry point resolution fails (e.g., all matches are utilities), the fallback strategy now:
1. Collects all function candidates matching keywords
2. Separates non-test files from test files
3. Prioritizes non-test implementation files
4. Only falls back to test files if no implementation files found

This prevents the system from analyzing test files when implementation files exist but weren't found by the primary strategy.

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No testing needed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.