### PR TITLE
Fix: Get file_path directly from node instead of calling non-existent…

### DIFF
--- a/cf/agents/pipelines/structural.py
+++ b/cf/agents/pipelines/structural.py
@@ -915,9 +915,9 @@ class StructuralPipeline:
                     result = self.kb.search_by_name(keyword, self.repo_id, node_type='Function')
                     for node in result.nodes:
                         qualified_name = node.get('qualified_name')
+                        file_path = node.get('file_path')  # File path is already in the node
                         if qualified_name and qualified_name not in seen_qnames:
                             seen_qnames.add(qualified_name)
-                            file_path = self.kb.get_file_path_for_qualified_name(qualified_name, self.repo_id)
                             candidates.append((qualified_name, file_path))
 
                 # Prioritize non-test files over test files


### PR DESCRIPTION
… method

The previous commit introduced a bug where it tried to call `self.kb.get_file_path_for_qualified_name()` which doesn't exist.

FunctionNode schema already includes file_path as a property, so we can get it directly from the node dictionary returned by search_by_name().

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No testing needed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.