### PR TITLE
Fix: Get file_path directly from node instead of calling non-existent…

### DIFF
--- a/cf/agents/pipelines/structural.py
+++ b/cf/agents/pipelines/structural.py
@@ -908,17 +908,45 @@ class StructuralPipeline:
             if not resolved:
                 print("   ⚠️ [KB_LIFEOFX] No entry point matches found, searching broader...")
 
-                # First pass: collect all candidates with their file paths
+                # Strategy 1: Search for functions by name
                 candidates = []
                 seen_qnames = set()
                 for keyword in keywords:
                     result = self.kb.search_by_name(keyword, self.repo_id, node_type='Function')
                     for node in result.nodes:
                         qualified_name = node.get('qualified_name')
-                        file_path = node.get('file_path')  # File path is already in the node
+                        file_path = node.get('file_path')
                         if qualified_name and qualified_name not in seen_qnames:
                             seen_qnames.add(qualified_name)
                             candidates.append((qualified_name, file_path))
+
+                # Strategy 2: Search for files by path, then get all their functions
+                # This catches entry points like "apps/applications/views.py::submit()"
+                # where the file path contains "application" but function name doesn't
+                for keyword in keywords:
+                    file_result = self.kb.search_by_name(keyword, self.repo_id, node_type='File')
+                    for file_node in file_result.nodes:
+                        file_path = file_node.get('file_path') or file_node.get('path')
+                        if not file_path or not self._is_entry_point_file(file_path):
+                            continue  # Skip non-entry-point files
+
+                        # Get all functions in this file
+                        func_result = self.kb.execute_query(
+                            """
+                            MATCH (f:Function {repo_id: $repo_id})
+                            WHERE f.file_path = $file_path
+                            RETURN f
+                            LIMIT 20
+                            """,
+                            {"repo_id": self.repo_id, "file_path": file_path}
+                        )
+                        for func_node in func_result.nodes:
+                            qualified_name = func_node.get('qualified_name')
+                            if qualified_name and qualified_name not in seen_qnames:
+                                seen_qnames.add(qualified_name)
+                                candidates.append((qualified_name, file_path))
+
+                print(f"   📊 [KB_LIFEOFX] Fallback found {len(candidates)} total candidates")
 
                 # Prioritize non-test files over test files
                 non_test_candidates = [(qname, fpath) for qname, fpath in candidates if not self._is_test_file(fpath)]

--- a/cf/agents/pipelines/structural.py
+++ b/cf/agents/pipelines/structural.py
@@ -850,12 +850,17 @@ class StructuralPipeline:
                 name_lower = qname.lower()
                 score = 0
 
+                # Check utility FIRST - utilities should not get entry point bonus
+                is_utility = self._is_utility_file(fpath)
+                is_entry_point = self._is_entry_point_file(fpath)
+
                 # HIGHEST priority: Entry point files (views, API endpoints, handlers)
-                if self._is_entry_point_file(fpath):
+                # But NOT if they're also utilities (factories, management commands)
+                if is_entry_point and not is_utility:
                     score += 100
 
-                # PENALTY: Utility files (managers, tasks, helpers)
-                if self._is_utility_file(fpath):
+                # PENALTY: Utility files (managers, tasks, helpers, factories, commands)
+                if is_utility:
                     score -= 50
 
                 # Name matching scores
@@ -999,7 +1004,9 @@ class StructuralPipeline:
             '/constants.py', '/config.py', '/settings.py',
             '/serializers.py',  # DRF serializers - data transformation
             '/permissions.py', '/middleware.py',
-            '/exceptions.py', '/validators.py'
+            '/exceptions.py', '/validators.py',
+            '/factories/',    # Factory pattern files - create objects, not entry points
+            '/management/commands/',  # Django management commands - CLI, not HTTP endpoints
         ]
 
         return any(pattern in path_lower for pattern in utility_patterns)


### PR DESCRIPTION
… method

The previous commit introduced a bug where it tried to call `self.kb.get_file_path_for_qualified_name()` which doesn't exist.

FunctionNode schema already includes file_path as a property, so we can get it directly from the node dictionary returned by search_by_name().

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No testing needed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.